### PR TITLE
feat: make input optional in create2Address

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -111,7 +111,7 @@ export function getDeployedContracts(receipt: ethers.providers.TransactionReceip
     return deployedContracts;
 }
 
-export function create2Address(sender: Address, bytecodeHash: BytesLike, salt: BytesLike, input: BytesLike) {
+export function create2Address(sender: Address, bytecodeHash: BytesLike, salt: BytesLike, input: BytesLike = '') {
     const prefix = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('zksyncCreate2'));
     const inputHash = ethers.utils.keccak256(input);
     const addressBytes = ethers.utils


### PR DESCRIPTION
In the case where there are no constructor arguments, passing undefined or null (or empty byte array) as the input results in the wrong keccak256 hash being generated. So make it optional and default to empty string which generates the correct hash.