### PR TITLE
Fix createAddress and create2Address

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -121,7 +121,7 @@ export function create2Address(
     const inputHash = ethers.keccak256(input);
     const addressBytes = ethers
         .keccak256(
-            ethers.concat([prefix, ethers.zeroPadBytes(sender, 32), salt, bytecodeHash, inputHash]),
+            ethers.concat([prefix, ethers.zeroPadValue(sender, 32), salt, bytecodeHash, inputHash]),
         )
         .slice(26);
     return ethers.getAddress(addressBytes);
@@ -133,8 +133,8 @@ export function createAddress(sender: Address, senderNonce: BigNumberish) {
         .keccak256(
             ethers.concat([
                 prefix,
-                ethers.zeroPadBytes(sender, 32),
-                ethers.zeroPadBytes(ethers.toBeHex(senderNonce), 32),
+                ethers.zeroPadValue(sender, 32),
+                ethers.zeroPadValue(ethers.toBeHex(senderNonce), 32),
             ]),
         )
         .slice(26);

--- a/tests/unit/util.test.ts
+++ b/tests/unit/util.test.ts
@@ -2,6 +2,25 @@ import { expect } from "chai";
 import { utils } from "../../src";
 
 describe("utils", () => {
+    describe("#createAddress", () => {
+        it("should return the correct address", async () => {
+            const address = utils.createAddress("0x36615Cf349d7F6344891B1e7CA7C72883F5dc049", 1);
+            expect(address).to.be.equal("0x4B5DF730c2e6b28E17013A1485E5d9BC41Efe021");
+        });
+    });
+
+    describe("#create2Address", () => {
+        it("should return the correct address", async () => {
+            const address = utils.create2Address(
+                "0x36615Cf349d7F6344891B1e7CA7C72883F5dc049",
+                "0x010001cb6a6e8d5f6829522f19fa9568660e0a9cd53b2e8be4deb0a679452e41",
+                "0x01",
+                "0x01",
+            );
+            expect(address).to.be.equal("0x29bac3E5E8FFE7415F97C956BFA106D70316ad50");
+        });
+    });
+
     describe("#applyL1ToL2Alias()", () => {
         it("should return the L2 contract address based on provided L1 contract address", async () => {
             const l1ContractAddress = "0x702942B8205E5dEdCD3374E5f4419843adA76Eeb";


### PR DESCRIPTION
# What :computer: 
Fixes #29 

# Why :hand:
`createAddress` and `create2Address` produce incorrect addresses

# Notes :memo:
The error seems to have occured in the ethers v5 -> v6 migration, where `ethers.utils.zeroPad`, which zero-pads left bits ([docs](https://docs.ethers.org/v5/api/utils/bytes/#utils-zeroPad)), was incorrectly replaced with `ethers.utils.zeroPadBytes`, which zero-pads the right bits ([docs](https://docs.ethers.org/v6/api/utils/#zeroPadBytes)). The correct replacement being `ethers.utils.zeroPadValue` ([docs](https://docs.ethers.org/v6/api/utils/#zeroPadValue))
